### PR TITLE
Le cadre en dessous ne mentionne que Grenoble

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
   <section id="sessions">
     <h2>Prochaines sessions</h2>
     <dl>
-      <dt>Paris</dt>
+      <dt>Grenoble</dt>
       <dd> le <strong><a href="https://public.etherpad-mozilla.org/p/TupperVim-Grenoble-1602">mercredi
         24 février de 20h à 22h</a></strong> au <a href="https://www.logre.eu/"
         title="Laboratoire Ouvert Grenoblois">LOG</a> : <strong>45 rue Nicolas Chorier,


### PR DESCRIPTION
Juste au dessus du cadre, Paris était mentionné alors que le seul Tuppervim de prévu est celui de Grenoble.