### PR TITLE
Ajout des archives des pads

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,6 +177,13 @@
   <section id="archives">
     <h2>Archives</h2>
     <ul>
+      <li> <a rel="nofollow" href="https://public.etherpad-mozilla.org/p/r.ef25ab0fae323ce6cf5c5f55d974f63c"><code>0x2F</code> (2016-05)</a> </li>
+      <li> <a rel="nofollow" href="https://public.etherpad-mozilla.org/p/r.77ff61cb4b62776e28bda4e7767bd789"><code>0x2E</code> (2016-04)</a> </li>
+      <li> <a rel="nofollow" href="https://public.etherpad-mozilla.org/p/r.0f018ae4186301572964d86f1b5e1d67"><code>0x2D</code> (2016-03)</a> </li>
+      <li> <a rel="nofollow" href="https://public.etherpad-mozilla.org/p/r.0f018ae4186301572964d86f1b5e1d67"><code>0x2C</code> (2016-02)</a> </li>
+      <li> <a rel="nofollow" href="https://public.etherpad-mozilla.org/p/r.7c9867437453c7b470d7f5de948d9db6"><code>0x2B</code> (2016-01)</a> </li>
+      <li> <a rel="nofollow" href="https://public.etherpad-mozilla.org/p/r.44d467d871fb2a9b9bcb64754165506b"><code>0x2A</code> (2015-12)</a> </li>
+      <li> <a rel="nofollow" href="https://public.etherpad-mozilla.org/p/r.89482213e8416fa4a3561a632aac2eea"><code>0x29</code> (2015-11)</a> </li>
       <li> <a rel="nofollow" href="https://old.etherpad-mozilla.org/TupperVim-1510"><code>0x28</code> (2015-10)</a> </li>
       <li> <a rel="nofollow" href="https://old.etherpad-mozilla.org/TupperVim-1509"><code>0x27</code> (2015-09)</a> </li>
       <li> <a rel="nofollow" href="https://old.etherpad-mozilla.org/TupperVim-1507"><code>0x26</code> (2015-07)</a> </li>


### PR DESCRIPTION
J'ai rajouté la liste des archives passées en utilisant les interfaces non éditables. On peut éventuellement faire mieux et on peut aussi s'interroger sur la pertinence de mettre le tuppervim raté de mars 2016.

Bisous aux canards