### PR TITLE
Remove romainl's dotvim repo

### DIFF
--- a/index.html
+++ b/index.html
@@ -273,7 +273,6 @@
           <li> <a rel="nofollow" href="https://github.com/Delapouite/dotfiles">https://github.com/Delapouite/dotfiles</a> </li>
           <li> <a rel="nofollow" href="https://github.com/GuillaumeSeren/vimrc">https://github.com/GuillaumeSeren/vimrc</a> </li>
           <li> <a rel="nofollow" href="https://github.com/HS-157/Dot-files">https://github.com/HS-157/Dot-files</a> </li>
-          <li> <a rel="nofollow" href="https://github.com/romainl/dotvim/">https://github.com/romainl/dotvim/</a> </li>
           <li> <a rel="nofollow" href="https://github.com/pbondoer/dotfiles">https://github.com/pbondoer/dotfiles</a> </li>
         </ul>
       </dd>


### PR DESCRIPTION
It has moved to gitlab, but is now private.

:(