### PR TITLE
Retour de l'historique / archives

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,6 +161,125 @@
     </ul>
   </section>
 
+  <section id="archives">
+    <h2>Historique / Archives</h2>
+    <b>Tous les anciens Pads antérieurs à 2018 ont été supprimés et les données perdues.</b>
+    <ul>
+      <li>Paris, Canal historique
+        <ul>
+          <li> <a rel="nofollow" href="https://mensuel.framapad.org/p/tuppervim-paris-1906"><code>0x44</code> (2019-06)</a> </li>
+          <li> <a rel="nofollow" href="https://mensuel.framapad.org/p/tuppervim-paris-1905"><code>0x43</code> (2019-05)</a> </li>
+          <li> <a rel="nofollow" href="https://mensuel.framapad.org/p/tuppervim-paris-1904"><code>0x42</code> (2019-04)</a> </li>
+          <li> <code>0x41</code> (2018-10) </li>
+          <li> <code>0x40</code> (2018-07) </li>
+          <li> <code>0x39</code> (2018-05) </li>
+          <li> <code>0x39</code> (2018-03) </li>
+          <li> <code>0x39</code> (2017-12) </li>
+          <li> <code>0x39</code> (2017-11) </li>
+          <li> <code>0x39</code> (2017-10) </li>
+          <li> <code>0x39</code> (2017-06) </li>
+          <li> <code>0x39</code> (2017-05) </li>
+          <li> <code>0x38</code> (2017-04) </li>
+          <li> <code>0x37</code> (2017-02) </li>
+          <li> <code>0x36</code> (2017-01) </li>
+          <li> <code>0x35</code> (2016-12) </li>
+          <li> <code>0x34</code> (2016-11) </li>
+          <li> <code>0x33</code> (2016-10) </li>
+          <li> <code>0x32</code> (2016-09) </li>
+          <li> <code>0x31</code> (2016-08) </li>
+          <li> <code>0x30</code> (2016-06) </li>
+          <li> <code>0x2F</code> (2016-05) </li>
+          <li> <code>0x2E</code> (2016-04) </li>
+          <li> <code>0x2D</code> (2016-03) </li>
+          <li> <code>0x2C</code> (2016-02) </li>
+          <li> <code>0x2B</code> (2016-01) </li>
+          <li> <code>0x2A</code> (2015-12) </li>
+          <li> <code>0x29</code> (2015-11) </li>
+          <li> <code>0x28</code> (2015-10) </li>
+          <li> <code>0x27</code> (2015-09) </li>
+          <li> <code>0x26</code> (2015-07) </li>
+          <li> <code>0x25</code> (2015-06) </li>
+          <li> <code>0x24</code> (2015-05) </li>
+          <li> <code>0x23</code> (2015-04) </li>
+          <li> <code>0x22</code> (2015-03) </li>
+          <li> <code>0x21</code> (2015-02) </li>
+          <li> <code>0x20</code> (2015-01) </li>
+          <li> <code>0x1F</code> (2014-12) </li>
+          <li> <code>0x1E</code> (2014-11) </li>
+          <li> <code>0x1D</code> (2014-10) </li>
+          <li> <code>0x1C</code> (2014-09) </li>
+          <li> <code>0x1B</code> (2014-08) </li>
+          <li> <code>0x1A</code> (2014-06) </li>
+          <li> <code>0x19</code> (2014-05) </li>
+          <li> <code>0x18</code> (2014-04) </li>
+          <li> <code>0x17</code> (2014-03) </li>
+          <li> <code>0x16</code> (2014-02) </li>
+          <li> <code>0x15</code> (2014-01) </li>
+          <li> <code>0x14</code> (2013-12) </li>
+          <li> <code>0x13</code> (2013-11) </li>
+          <li> <code>0x12</code> (2013-10) </li>
+          <li> <code>0x11</code> (2013-09) </li>
+          <li> <code>0x10</code> (2013-06) </li>
+          <li> <code>0x0F</code> (2013-05) </li>
+          <li> <code>0x0E</code> (2013-04) </li>
+          <li> <code>0x0D</code> (2013-03) </li>
+          <li> <code>0x0C</code> (2013-02) </li>
+          <li> <code>0x0B</code> (2013-01) </li>
+          <li> <code>0x0A</code> (2012-12) </li>
+          <li> <code>0x08</code> (2012-10) </li>
+          <li> <code>0x07</code> (2012-09) </li>
+          <li> <code>0x06</code> (2012-08) </li>
+          <li> <code>0x05</code> (2012-07) </li>
+          <li> <code>0x04</code> (2012-06) </li>
+          <li> <code>0x02</code> (2012-04) </li>
+          <li> <code>0x01</code> (2012-03) </li>
+        </ul>
+      </li>
+      <li>Grenoble
+        <ul>
+          <li> <code>0x09</code> (2018-10) </li>
+          <li> <code>0x08</code> (2018-08) </li>
+          <li> <code>0x07</code> (2018-07) </li>
+          <li> <code>0x06</code> (2017-11) </li>
+          <li> <code>0x06</code> (2017-03) </li>
+          <li> <code>0x05</code> (2016-10) </li>
+          <li> <code>0x04</code> (2016-06) </li>
+          <li> <code>0x03</code> (2016-04) </li>
+          <li> <code>0x02</code> (2016-02) </li>
+          <li> <code>0x01</code> (2015-12) </li>
+        </ul>
+      </li>
+      <li>Lyon
+        <ul>
+          <li> <code>0x08</code> (2019-07) </li>
+          <li> <a rel="nofollow" href="https://pad.hadoly.fr/p/TupperVim-lyon-1907"><code>0x08</code> (2018-07)</a> </li>
+          <li> <code>0x07</code> (2019-01) </li>
+          <li> <a rel="nofollow" href="https://pad.hadoly.fr/p/TupperVim-lyon-1901"><code>0x06</code> (2019-01)</a> </li>
+          <li> <code>0x06</code> (2018-06) </li>
+          <li> <code>0x06</code> (2018-03) </li>
+          <li> <code>0x05</code> (2018-01) </li>
+          <li> <code>0x04</code> (2017-10) </li>
+          <li> <code>0x04</code> (2017-04) </li>
+          <li> <code>0x04</code> (2017-02) </li>
+          <li> <code>0x03</code> (2016-11) </li>
+          <li> <code>0x02</code> (2016-06) </li>
+          <li> <code>0x01</code> (2016-01) </li>
+        </ul>
+      </li>
+      <li>Lille
+        <ul>
+          <li> <code>0x01</code> (2017-02) </li>
+        </ul>
+      </li>
+      <li>Nantes
+        <ul>
+          <li> <code>0x02</code> (2018-03)</li>
+          <li> <code>0x01</code> (2017-04)</li>
+        </ul>
+      </li>
+        </ul>
+  </section>
+
   <section id="liens">
     <h2>Liens</h2>
     <dl>


### PR DESCRIPTION
@maggick @fflorent @fabi1cazenave 

Je remets l'historique qui avait été supprimé à https://github.com/tupperVim/tuppervim.github.io/commit/6671aa020bd6c8e059a32aeda9a06495acf8730b  . J'ai rajouté les dates de 2017 et 2018 et 2019 qui n'avaient pas été mises. 

Lorsque l'on crée un nouveau Framapad ils mettent en garde contre le fait que les Pads sont supprimés au bout de 31 jours sans éditions. Les Framapad postérieurs aux 19 04 n'ont pas encore été virés. 

Il semblerait  que les Pad de https://pad.hadoly.fr/ soient conservés, contrairement à ceux de Framapad qui sont virés au bout de 31 jours sans éditions, d'après leur dire. En tout cas ceux créés par @fflorent  n'ont pas encore été virés.

Pour le futur, il serait peut-être cool de n'utiliser plus que les Pad de Hadoly ?

Ou mieux, ceux de Grésille https://www.gresille.org/services/etherpad/ ? Comme on connaît les gens de Grésille ce serait plus simple pour la gestion ? @fabi1cazenave j'ai croisé récemment un TupperVimist de Grenoble qui m'a venté les mérites de Grésille. 

Pareil pour la Mailing List. Sachant que Framasoft a une politique de suppression des archives, je vote plus pour Grésille que pour Framasoft !

On en discute le 4 juillet !